### PR TITLE
bump packages 🤜

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log*
 
 # vercel
 .vercel
+pnpm-lock.yaml

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,7 +1,7 @@
 import styles from "../Layout/Layout.module.css";
 import Link from "next/link";
 import Head from "next/head";
-import NavBar from "../NavBar/NavBar";
+import NavBar from "../navBar/NavBar";
 import Footer from "../Footer/Footer";
 
 export default function Layout({ children }) {

--- a/components/navBar/MobileNavigation.jsx
+++ b/components/navBar/MobileNavigation.jsx
@@ -1,7 +1,7 @@
 import  Navlinks from "./NavLinks"
 import styles from "../navBar/NavBar.module.css";
-import {ImMenu} from 'react-icons/Im'
-import {FaWindowClose} from 'react-icons/Fa'
+import {ImMenu} from 'react-icons/im'
+import {FaWindowClose} from 'react-icons/fa'
 import {useState} from 'react'
 
 const MobileNavigation = () => {

--- a/package.json
+++ b/package.json
@@ -8,16 +8,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "@zeit/next-sass": "^1.0.1",
     "bulma": "^0.9.3",
-    "contentful": "^9.0.3",
+    "contentful": "^9.1.12",
     "icons": "^1.0.0",
-    "next": "^12.0.8",
+    "next": "^12.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-icons": "^4.3.1"
-  },
-  "devDependencies": {
-    "sass": "^1.49.0"
+    "react-icons": "^4.3.1",
+    "sass": "^1.49.9"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import { createClient } from "contentful";
 import GridComp from "../components/gridComp/gridComp";
-import NavBar from "../components/NavBar/NavBar";
+import NavBar from "../components/navBar/NavBar";
 import Footer from "../components/Footer/Footer";
 import Head from "next/head";
 import ResultModal from "../components/ResultModal/ResultModal";


### PR DESCRIPTION
I briefly checked the code on `main` and it's looking good. In order to get it running I just needed to change the import /NavBar/NavBar to lowercase /navBar/NavBar

I also got some dependency errors, but they were easily fixed by removing @zeit/next-sass.
Nextjs has sass support built in https://nextjs.org/docs/basic-features/built-in-css-support
I also bumped the packages up with `ncu`. It might be that the newest version of react-icons uses all lowercase in the newer version, because I had to change 'react-icons/im' and 'react-icons/fm'

I'm also not sure if the 'icons' package is ever used. It is complaining that it's deprecated...
